### PR TITLE
extrapolators: Fix extrapolators sometimes reducing precision

### DIFF
--- a/chia/components/extrapolators/adaptive.py
+++ b/chia/components/extrapolators/adaptive.py
@@ -1,6 +1,7 @@
 import collections
 import typing
 
+import networkx as nx
 import numpy as np
 
 from chia.components.extrapolators.extrapolator import Extrapolator
@@ -32,11 +33,14 @@ class ICGainRangeExtrapolator(Extrapolator):
         target_ic = ground_truth_ic + self._ic_gain_target
         half_range = self._ic_range / 2.0
 
+        allowed_candidates = set(nx.descendants(self._rgraph, ground_truth_uid))
+
         candidates = [
             uid
             for (uid, probability) in unconditional_probabilities.items()
             if -half_range <= (self._ic_cache[uid] - target_ic) <= half_range
             and probability >= self._probability_threshold
+            and uid in allowed_candidates
         ]
 
         if len(candidates) > 0:
@@ -90,10 +94,13 @@ class AdaptiveICGainExtrapolator(Extrapolator):
 
     def _extrapolate(self, ground_truth_uid, unconditional_probabilities):
         """This is basically the same as SimpleThresholdCHILLAXExtrapolator, just with added reporting etc."""
+
+        allowed_candidates = set(nx.descendants(self._rgraph, ground_truth_uid))
+
         candidates = [
             uid
             for (uid, probability) in unconditional_probabilities.items()
-            if probability >= self._threshold
+            if probability >= self._threshold and uid in allowed_candidates
         ]
 
         if len(candidates) > 0:

--- a/chia/components/extrapolators/extrapolator.py
+++ b/chia/components/extrapolators/extrapolator.py
@@ -145,10 +145,12 @@ class DoNothingExtrapolator(Extrapolator):
 
 class ForcePredictionTargetExtrapolator(Extrapolator):
     def _extrapolate(self, ground_truth_uid, unconditional_probabilities):
+        allowed_candidates = set(nx.descendants(self._rgraph, ground_truth_uid))
+
         candidates = [
             uid
             for (uid, probability) in unconditional_probabilities.items()
-            if uid in self._prediction_targets
+            if uid in self._prediction_targets.intersection(allowed_candidates)
         ]
 
         if len(candidates) > 0:

--- a/chia/components/extrapolators/fixed.py
+++ b/chia/components/extrapolators/fixed.py
@@ -23,10 +23,12 @@ class SimpleThresholdExtrapolator(Extrapolator):
         self._threshold = threshold
 
     def _extrapolate(self, ground_truth_uid, unconditional_probabilities):
+        allowed_candidates = set(nx.descendants(self._rgraph, ground_truth_uid))
+
         candidates = [
             uid
             for (uid, probability) in unconditional_probabilities.items()
-            if probability >= self._threshold
+            if probability >= self._threshold and uid in allowed_candidates
         ]
 
         if len(candidates) > 0:


### PR DESCRIPTION
In very rare cases, some extrapolators can return results that are less precise in terms of depth than the ground truth. This behavior comes from the implicit assumption that the order induced by the selected IC measurement is identical to the order induced by the hyponymy relation. However, this is only true for tree-type hierarchies. See [this example](https://gist.github.com/cabrust/71cb7a38ba7183068e7b6afa8439097e).

This PR fixes the behavior by restricting the possible candidates to descendants of the ground truth. However, it does not affect any previous experimental results for self-supervised CHILLAX, as the datasets used all come with tree-type hierarchies.